### PR TITLE
Travis containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
     - 2.7
     - 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_install:
     - conda create -q -n mic-test python=$TRAVIS_PYTHON_VERSION numpy scipy pillow scikit-learn scikit-image cytoolz pandas setuptools pip pymongo matplotlib six
     - source activate mic-test
 
-    - pip install -U setuptools
     - pip install pytest pytest-cov
     - pip install coveralls
 


### PR DESCRIPTION
Use containers instead of VMs for Travis CI. Shaves about 30s off build times.