### PR TITLE
Correct illumination and stretch images based on whole plate

### DIFF
--- a/microscopium/_util.py
+++ b/microscopium/_util.py
@@ -1,3 +1,5 @@
+import numpy as np
+import numbers
 
 def groupby(key, iterable, transform=None):
     """Group items in `iterable` in a dictionary according to `key`.
@@ -25,3 +27,32 @@ def groupby(key, iterable, transform=None):
         grouped.setdefault(key(elem), []).append(transform(elem))
     return grouped
 
+
+def normalise_random_state(seed):
+    """Turn seed into a numpy RandomState instance.
+
+    Parameters
+    ----------
+    seed : None, int, or numpy RandomState instance
+        The input seed/random state.
+
+    Returns
+    -------
+    random : numpy RandomState instance.
+        The resulting RandomState instance.
+
+    Notes
+    -----
+    This function is copied almost verbatim from scikit-learn's
+    ``sklearn.utils.validation.check_random_state``, and so is
+    governed by that library's code license (New BSD at the time of
+    this writing.)
+    """
+    if seed is None:
+        return np.random.mtrand._rand
+    if isinstance(seed, (numbers.Integral, np.integer)):
+        return np.random.RandomState(seed)
+    if isinstance(seed, np.random.RandomState):
+        return seed
+    else:
+        raise ValueError('Invalid input %s to generate random state' % seed)

--- a/microscopium/main.py
+++ b/microscopium/main.py
@@ -55,14 +55,6 @@ illum.add_argument('-f', '--file-list', type=lambda x: open(x, 'r'),
 illum.add_argument('-o', '--output-suffix',
                    default='.illum.tif', metavar='SUFFIX',
                    help="What suffix to attach to the corrected images.")
-illum.add_argument('-M', '--use-mask', action='store_true',
-                   help="Mask out abnormally bright parts of the image.")
-illum.add_argument('-m', '--mask-offset', metavar='INT', default=0, type=int,
-                  help='Offset the automatic mask threshold by this amount.')
-illum.add_argument('-c', '--mask-close', metavar='RADIUS', default=0, type=int,
-                  help='Perform morphological closing of masks of this radius.')
-illum.add_argument('-e', '--mask-erode', metavar='RADIUS', default=0, type=int,
-                  help='Perform morphological erosion of masks of this radius.')
 illum.add_argument('-l', '--stretchlim', metavar='[0.0-1.0]', type=float,
                    default=0.0, help='Stretch image range before all else.')
 illum.add_argument('-L', '--stretchlim-output', metavar='[0.0-1.0]', type=float,
@@ -76,6 +68,9 @@ illum.add_argument('-s', '--save-illumination', metavar='FN',
                    help='Save the illumination field to a file.')
 illum.add_argument('-v', '--verbose', action='store_true',
                    help='Print runtime information to stdout.')
+illum.add_argument('--method', metavar='STR', default='median',
+                   help='How to collapse filtered images to illumination '
+                        'field. options: median (default), mean.')
 
 
 stitch = subpar.add_parser('stitch', 
@@ -178,23 +173,16 @@ def run_illum(args):
         args.images.extend([fn.rstrip() for fn in args.file_list])
     il = pre.find_background_illumination(args.images, args.radius,
                                           args.quantile, args.stretchlim,
-                                          args.use_mask, args.mask_offset,
-                                          args.mask_close, args.mask_erode)
+                                          args.method)
     if args.verbose:
         print('illumination field:', type(il), il.dtype, il.min(), il.max())
     if args.save_illumination is not None:
         io.imsave(args.save_illumination, il / il.max())
     base_fns = [pre.basefn(fn) for fn in args.images]
     ims_out = [fn + args.output_suffix for fn in base_fns]
-    mask_fns = [fn + '.mask.tif' for fn in base_fns]
-    ims = (io.imread(fn) for fn in args.images)
-    for im, fout, mask_fn in it.izip(ims, ims_out, mask_fns):
-        if os.path.isfile(mask_fn):
-            mask = io.imread(mask_fn).astype(bool)
-        else:
-            mask = np.ones(im.shape, bool)
-        im = pre.correct_image_illumination(im, il,
-                                            args.stretchlim_output, mask)
+    corrected = pre.correct_multiimage_illumination(args.images, il,
+                                                    args.stretchlim_output)
+    for im, fout in zip(corrected, ims_out):
         io.imsave(fout, im)
 
 

--- a/microscopium/main.py
+++ b/microscopium/main.py
@@ -1,12 +1,10 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 #!/bin/env python
 
 # standard library
 import os
 import sys
 import argparse
-import itertools as it
 
 # dependencies
 import numpy as np
@@ -17,7 +15,7 @@ from skimage import io, img_as_ubyte
 from . import io as hio
 from . import screens
 from . import preprocess as pre
-from six.moves import map
+from six.moves import map, zip
 
 
 parser = argparse.ArgumentParser(description="Run the HUSC functions.")
@@ -219,10 +217,10 @@ def run_cat(args):
     args : argparse.Namespace
         The arguments parsed by the argparse library.
     """
-    ims = it.imap(io.imread, args.images)
+    ims = map(io.imread, args.images)
     ims_out = hio.cat_channels(ims)
     out_fns = [os.path.splitext(fn)[0] + '.chs.tif' for fn in args.images[::3]]
-    for im, fn in it.izip(ims_out, out_fns):
+    for im, fn in zip(ims_out, out_fns):
         try:
             io.imsave(fn, im)
         except ValueError:
@@ -238,7 +236,7 @@ def run_features(args):
     args : argparse.Namespace
         The arguments parsed by the argparse library.
     """
-    images = it.imap(io.imread, args.images)
+    images = map(io.imread, args.images)
     screen_info = screens.d[args.screen]
     index_function, fmap = screen_info['index'], screen_info['fmap']
     f0, feature_names = fmap(next(images))

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -8,8 +8,8 @@ import numpy as np
 from scipy import ndimage as nd
 from skimage import io
 from scipy.stats.mstats import mquantiles as quantiles
-from skimage import morphology as skmorph, filter as imfilter
-import skimage.filter.rank as rank
+from skimage import morphology as skmorph, filters as imfilter
+import skimage.filters.rank as rank
 import skimage
 import cytoolz as tlz
 from six.moves import map

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -609,6 +609,8 @@ def correct_multiimage_illumination(im_fns, illum, stretch_quantile=0):
     p0 = 100 * stretch_quantile
     p1 = 100 - p0
     im_fns = list(im_fns)
+
+    # in first pass, make a composite image to get global intensity range
     ims_pass1 = map(io.imread, im_fns)
     sampled = _reservoir_sampled_image(ims_pass1)
     corrected = sampled / illum  # don't do in-place, dtype may clash

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -641,6 +641,14 @@ def _reservoir_sampled_image(ims_iter, random_state=None):
     -------
     sampled : array, same shape as input
         The sampled "image".
+
+    Examples
+    --------
+    >>> ims = np.arange(27).reshape((3, 3, 3))
+    >>> _reservoir_sampled_image(iter(ims), 0)
+    array([[ 0,  1,  2],
+           [ 3, 13, 23],
+           [24, 25,  8]])
     """
     random = normalise_random_state(random_state)
     ims_iter = iter(ims_iter)  # ensure iterator and not e.g. list

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -618,7 +618,7 @@ def correct_multiimage_illumination(im_fns, illum, stretch_quantile=0,
     ims_pass1 = map(io.imread, im_fns)
     sampled = _reservoir_sampled_image(ims_pass1, random_state)
     corrected = sampled / illum  # don't do in-place, dtype may clash
-    corr_range = np.percentile(corrected, [p0, p1])
+    corr_range = tuple(np.percentile(corrected, [p0, p1]))
 
     # In second pass, correct every image and adjust exposure
     ims_pass2 = map(io.imread, im_fns)

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -642,8 +642,8 @@ def _reservoir_sampled_image(ims_iter, random_state=None):
 
     Parameters
     ----------
-    ims_iter : iterator of arrays
-        An iterator over numpy arrays (representing images).
+    ims_iter : iterable of arrays
+        An iterable over numpy arrays (representing images).
     random_state : None, int, or numpy RandomState instance, optional
         An optional random number generator or seed from which to draw
         samples.

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -643,6 +643,7 @@ def _reservoir_sampled_image(ims_iter, random_state=None):
         The sampled "image".
     """
     random = normalise_random_state(random_state)
+    ims_iter = iter(ims_iter)  # ensure iterator and not e.g. list
     sampled = next(ims_iter)
     for k, im in enumerate(ims_iter, start=2):
         to_replace = random.rand(*im.shape) < (1 / k)

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -578,7 +578,8 @@ def find_background_illumination(fns, radius=51, quantile=0.05,
     return illum
 
 
-def correct_multiimage_illumination(im_fns, illum, stretch_quantile=0):
+def correct_multiimage_illumination(im_fns, illum, stretch_quantile=0,
+                                    random_state=None):
     """Divide input images pointwise by the illumination field.
 
     However, where `correct_image_illumination` rescales each individual
@@ -596,6 +597,9 @@ def correct_multiimage_illumination(im_fns, illum, stretch_quantile=0):
     stretch_quantile : float, optional
         Clip intensity above and below this quantile. Stretch remaining
         values to fill dynamic range.
+    random_state : None, int, or numpy RandomState instance, optional
+        An optional random number generator or seed, passed directly to
+        `_reservoir_sampled_image`.
 
     Returns
     -------
@@ -612,7 +616,7 @@ def correct_multiimage_illumination(im_fns, illum, stretch_quantile=0):
 
     # in first pass, make a composite image to get global intensity range
     ims_pass1 = map(io.imread, im_fns)
-    sampled = _reservoir_sampled_image(ims_pass1)
+    sampled = _reservoir_sampled_image(ims_pass1, random_state)
     corrected = sampled / illum  # don't do in-place, dtype may clash
     corr_range = np.percentile(corrected, [p0, p1])
 

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -173,7 +173,7 @@ def maxes(fns):
     return maxes
 
 
-def stretchlim(im, bottom=0.01, top=None, mask=None, in_place=False):
+def stretchlim(im, bottom=0.001, top=None, mask=None, in_place=False):
     """Stretch the image so new image range corresponds to given quantiles.
 
     Parameters

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -635,6 +635,11 @@ def _reservoir_sampled_image(ims_iter, random_state=None):
     The idea is to get a sample of image intensity throughout a collection
     of images, to know what the "standard range" is for this type of image.
 
+    The implementation uses a "reservoir" image to sample while remaining
+    space-efficient, and only needs to hold about four images at one time
+    (the reservoir, the current sample, a random image for sampling, and
+    a thresholded version of the random image).
+
     Parameters
     ----------
     ims_iter : iterator of arrays

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -541,7 +541,7 @@ def find_background_illumination(fns, radius=51, quantile=0.05,
 
     See Also
     --------
-    ``correct_image_illumination``.
+    `correct_image_illumination`, `correct_multiimage_illumination`.
     """
     # This function follows the "PyToolz" streaming data model to
     # obtain the illumination estimate. First, define each processing
@@ -685,6 +685,10 @@ def correct_image_illumination(im, illum, stretch_quantile=0, mask=None):
     -------
     imc : np.ndarray of float, same shape as `im`
         The corrected image.
+
+    See Also
+    --------
+    `correct_multiimage_illumination`
     """
     if im.dtype != np.float:
         imc = skimage.img_as_float(im)

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -655,8 +655,8 @@ def _reservoir_sampled_image(ims_iter, random_state=None):
 
     Examples
     --------
-    >>> ims = np.arange(27).reshape((3, 3, 3))
-    >>> _reservoir_sampled_image(iter(ims), 0)
+    >>> ims = iter(np.arange(27).reshape((3, 3, 3)))
+    >>> _reservoir_sampled_image(ims, 0)
     array([[ 0,  1,  2],
            [ 3, 13, 23],
            [24, 25,  8]])


### PR DESCRIPTION
Fixes #38.

Or it should, anyway, haven't tested on real data yet. =P

I recommend a `--stretchlim-output` setting of 0.001 or thereabouts, or all images will be scaled to the brightest fluff. (at least if it makes it through the sampling; but presumably one or two pixels will...)