### PR TITLE
Update Mongo query in metrics.py to be PyMongo3 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
     - conda update -q conda
     - conda info -a
 
-    - conda create -q -n mic-test python=$TRAVIS_PYTHON_VERSION numpy scipy pillow scikit-learn scikit-image toolz cytoolz pandas setuptools pip pymongo matplotlib=1.5.0 six h5py
+    - conda create -q -n mic-test python=$TRAVIS_PYTHON_VERSION numpy scipy pillow scikit-learn scikit-image toolz cytoolz pandas setuptools pip pymongo matplotlib six h5py
     - source activate mic-test
 
     - pip install pytest coverage pytest-cov sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
     - conda update -q conda
     - conda info -a
 
-    - conda create -q -n mic-test python=$TRAVIS_PYTHON_VERSION numpy scipy pillow scikit-learn scikit-image toolz cytoolz pandas setuptools pip pymongo matplotlib=0.15.0 six h5py
+    - conda create -q -n mic-test python=$TRAVIS_PYTHON_VERSION numpy scipy pillow scikit-learn scikit-image toolz cytoolz pandas setuptools pip pymongo matplotlib=1.5.0 six h5py
     - source activate mic-test
 
     - pip install pytest coverage pytest-cov sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
     - conda update -q conda
     - conda info -a
 
-    - conda create -q -n mic-test python=$TRAVIS_PYTHON_VERSION numpy scipy pillow scikit-learn scikit-image toolz cytoolz pandas setuptools pip pymongo=2.8 matplotlib six h5py
+    - conda create -q -n mic-test python=$TRAVIS_PYTHON_VERSION numpy scipy pillow scikit-learn scikit-image toolz cytoolz pandas setuptools pip pymongo matplotlib six h5py
     - source activate mic-test
 
     - pip install pytest coverage pytest-cov sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
     - conda update -q conda
     - conda info -a
 
-    - conda create -q -n mic-test python=$TRAVIS_PYTHON_VERSION numpy scipy pillow scikit-learn scikit-image toolz cytoolz pandas setuptools pip pymongo matplotlib six h5py
+    - conda create -q -n mic-test python=$TRAVIS_PYTHON_VERSION numpy scipy pillow scikit-learn scikit-image toolz cytoolz pandas setuptools pip pymongo matplotlib=0.15.0 six h5py
     - source activate mic-test
 
     - pip install pytest coverage pytest-cov sh

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
 - pandas=0.16.2=np19py34_0
 - pillow=3.0.0=py34_0
 - pip=7.1.2=py34_0
-- pymongo=2.8=py34_0
+- pymongo=3.0.3=py34_0
 - pyparsing=2.0.3=py34_0
 - pyqt=4.11.3=py34_0
 - python=3.4.3=0

--- a/microscopium/metrics.py
+++ b/microscopium/metrics.py
@@ -98,7 +98,7 @@ def mongo_group_by(collection, group_by):
                     }
                 }
             }
-    }])['result']
+    }])
 
     query_dict = {}
     for doc in mongo_query:

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -632,7 +632,7 @@ def correct_multiimage_illumination(im_fns, illum, stretch_quantile=0,
         corrected = im / illum
         rescaled = exposure.rescale_intensity(corrected, in_range=corr_range,
                                               out_range=np.uint8)
-        out = np.round(rescaled, out=np.empty(rescaled.shape, np.uint8))
+        out = np.round(rescaled).astype(np.uint8)
         yield out
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ toolz
 cytoolz
 h5py
 ujson
-pymongo==2.8.1
+pymongo
 pandas
 pytest
 sh


### PR DESCRIPTION
So this was pretty easy, see the PyMongo [docs](http://api.mongodb.org/python/current/api/pymongo/collection.html#pymongo.collection.Collection.aggregate). PyMongo 3.x returns a cursor from an aggregation query now. The cursor isn't accessed with the ``result`` key anymore.