### PR TITLE
Add dask support to montage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
     - conda update -q conda
     - conda info -a
 
-    - conda create -q -n mic-test python=$TRAVIS_PYTHON_VERSION numpy scipy pillow scikit-learn scikit-image toolz cytoolz pandas setuptools pip pymongo=2.8 matplotlib six h5py
+    - conda create -q -n mic-test python=$TRAVIS_PYTHON_VERSION numpy scipy pillow scikit-learn scikit-image toolz cytoolz dask pandas setuptools pip pymongo=2.8 matplotlib six h5py
     - source activate mic-test
 
     - pip install pytest coverage pytest-cov sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-    - 2.7
     - 3.4
 virtualenv:
     system_site_packages: false

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -634,7 +634,7 @@ def correct_multiimage_illumination(im_fns, illum, stretch_quantile=0,
         corrected = im / illum
         rescaled = exposure.rescale_intensity(corrected, in_range=corr_range,
                                               out_range=np.uint8)
-        out = np.round(rescaled, out=np.empty(rescaled.shape, np.uint8))
+        out = np.round(rescaled).astype(np.uint8)
         yield out
 
 

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -1000,7 +1000,7 @@ def montage_parallel(images, montage_order=None, channel_order=None,
     montage_ = func.partial(montage, order=montage_order)
     bag = db.from_sequence(images, partition_size=(ntiles * nchannels *
                                                  montages_per_partition))
-    return bag.map_partitions(func.partial(tz.partition, nchannels))
-              .map(stack)
-              .map_partitions(func.partial(tz.partition, ntiles))
-              .map(montage_)
+    return (bag.map_partitions(func.partial(tz.partition, nchannels))
+               .map(stack)
+               .map_partitions(func.partial(tz.partition, ntiles))
+               .map(montage_))

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -800,7 +800,7 @@ def montage(ims, order=None):
     rows, cols = ims[0].shape[:2]
     mrows, mcols = order.shape
 
-    montaged = np.zeros((rows * mrows, cols * mcols) + ims[0].shape[2:],
+    montaged = np.empty((rows * mrows, cols * mcols) + ims[0].shape[2:],
                         dtype=ims[0].dtype)
     for i in range(mrows):
         for j in range(mcols):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ scikit-image
 six
 toolz
 cytoolz
+dask
 h5py
 ujson
 pymongo==2.8.1


### PR DESCRIPTION
Two further improvements should be made here, but they could wait for a further PR:
1. Currently, exactly `ncpu` partitions are sent a dask object at a time. This means that there is zero load balancing going on. We should figure out a good number of partitions to make depending on memory.
2. We might still want to change our interface to take image filenames instead of images. This is because multiprocessing forks the process, so right now we are loading the images in a process and then forking, which is probably a significant inefficiency hit compared to loading only filenames.

@starcalibre feel free to merge though, if this works for you, and we can raise issues to address the above.

Thanks!
