### PR TITLE
Add generalised spiral array function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,9 @@ nosetests.xml
 .project
 .pydevproject
 
-# PyCharm
+# PyCharm / IntelliJ
 .idea/
+*.iml
 
 # Data directories
 data/

--- a/microscopium/_util.py
+++ b/microscopium/_util.py
@@ -1,6 +1,81 @@
 import numpy as np
 import numbers
 
+
+def generate_spiral(dim, direction, clockwise=False):
+    """Generate an dim * dim of sequental integers in a spiral pattern.
+
+    Many HCS systems use a spiral pattern to capture multiple fields in
+    for each well. This function generates a spiral pattern of integers
+    to be used by the montaging functions.
+
+    Parameters
+    ----------
+    dim : int
+        The dimension of the spiral. The function will return a dim * dim
+        array.
+    direction : str
+        The direction the first step the spiral takes when leaving the origin.
+        Should be one of up, down, left or right.
+    clockwise : bool, optional
+        The direction of the spiral. Default clockwise.
+
+    Returns
+    -------
+    spiral_array : array, shape (dim, dim)
+        The spiral array.
+
+    Examples
+    --------
+    >>> generate_spiral(3, "up", True)
+    array([[8, 1, 2],
+           [7, 0, 3],
+           [6, 5, 4]], dtype=uint8)
+    """
+    if dim <= 0:
+        raise ValueError("dim must be a positive integer.")
+
+    if dim % 2 != 1:
+        raise ValueError("dim must be an odd integer.")
+
+    if direction not in ["down", "up", "left", "right"]:
+        raise ValueError("direction must be one of down, up, left or right.")
+
+    directions = {
+        "down": [1, 0],
+        "up": [-1, 0],
+        "left": [0, -1],
+        "right": [0, 1]
+    }
+
+    di, dj = directions[direction]
+    segment_length = 1
+    i = j = segment_passed = 0
+    center = np.floor(dim / 2).astype(np.uint8)
+    spiral_array = np.zeros((dim, dim), dtype=np.uint8)
+
+    for k in range(1, dim ** 2):
+        i += di
+        j += dj
+        segment_passed += 1
+        spiral_array[center + i][center + j] = k
+
+        if segment_passed == segment_length:
+            segment_passed = 0
+            if clockwise:
+                di, dj = dj, -di
+            else:
+                di, dj = -dj, di
+            if direction in ["left", "right"]:
+                if di == 0:
+                    segment_length += 1
+            else:
+                if dj == 0:
+                    segment_length += 1
+
+    return spiral_array
+
+
 def groupby(key, iterable, transform=None):
     """Group items in `iterable` in a dictionary according to `key`.
 

--- a/microscopium/_util.py
+++ b/microscopium/_util.py
@@ -18,7 +18,8 @@ def generate_spiral(dim, direction, clockwise=False):
         The direction the first step the spiral takes when leaving the origin.
         Should be one of up, down, left or right.
     clockwise : bool, optional
-        The direction of the spiral. Default clockwise.
+        If the spiral generated should be in a clockwise direction. Default
+        true.
 
     Returns
     -------

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -632,7 +632,7 @@ def correct_multiimage_illumination(im_fns, illum, stretch_quantile=0,
         corrected = im / illum
         rescaled = exposure.rescale_intensity(corrected, in_range=corr_range,
                                               out_range=np.uint8)
-        out = np.round(rescaled, out=np.empty(rescaled.shape, np.uint8))
+        out = np.round(rescaled, out=np.empty(rescaled.shape)).astype(np.uint8)
         yield out
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,78 @@
+from microscopium._util import generate_spiral
+import pytest
+import numpy as np
+
+spiral_3_down_anticlockwise = [[6, 5, 4],
+                               [7, 0, 3],
+                               [8, 1, 2]]
+
+spiral_5_right_clockwise = [[20, 21, 22, 23, 24],
+                            [19,  6,  7,  8,  9],
+                            [18,  5,  0,  1, 10],
+                            [17,  4,  3,  2, 11],
+                            [16, 15, 14, 13, 12]]
+
+spiral_5_up_anticlockwise = [[12, 11, 10,  9, 24],
+                             [13,  2,  1,  8, 23],
+                             [14,  3,  0,  7, 22],
+                             [15,  4,  5,  6, 21],
+                             [16, 17, 18, 19, 20]]
+
+spiral_7_left_clockwise = [[30, 31, 32, 33, 34, 35, 36],
+                           [29, 12, 13, 14, 15, 16, 37],
+                           [28, 11,  2,  3,  4, 17, 38],
+                           [27, 10,  1,  0,  5, 18, 39],
+                           [26,  9,  8,  7,  6, 19, 40],
+                           [25, 24, 23, 22, 21, 20, 41],
+                           [48, 47, 46, 45, 44, 43, 42]]
+
+spiral_3_down_anticlockwise_params = ("spiral_3_left_clockwise", {
+    "dim": 3,
+    "direction": "down",
+    "clockwise": False,
+    "expected": spiral_3_down_anticlockwise
+})
+
+spiral_5_right_clockwise_params = ("spiral_3_left_clockwise", {
+    "dim": 5,
+    "direction": "right",
+    "clockwise": True,
+    "expected": spiral_5_right_clockwise
+})
+
+spiral_5_up_anticlockwise_params = ("spiral_3_left_clockwise", {
+    "dim": 5,
+    "direction": "up",
+    "clockwise": False,
+    "expected": spiral_5_up_anticlockwise
+})
+
+spiral_7_left_clockwise_params = ("spiral_7_left_clockwise", {
+    "dim": 7,
+    "direction": "left",
+    "clockwise": True,
+    "expected": spiral_7_left_clockwise
+})
+
+
+def pytest_generate_tests(metafunc):
+    idlist = []
+    argvalues = []
+    for scenario in metafunc.cls.scenarios:
+        idlist.append(scenario[0])
+        argnames = list(scenario[1].keys())
+        argvalues.append((list(scenario[1].values())))
+    metafunc.parametrize(argnames, argvalues, ids=idlist, scope="class")
+
+
+class TestSeries:
+    scenarios = [spiral_3_down_anticlockwise_params,
+                 spiral_5_right_clockwise_params,
+                 spiral_5_up_anticlockwise_params,
+                 spiral_7_left_clockwise_params]
+
+    def test_generate_spiral(self, dim, direction, clockwise,
+                                    expected):
+        actual = generate_spiral(dim, direction, clockwise)
+        np.testing.assert_array_equal(actual, expected)
+


### PR DESCRIPTION
Function to generate spiral arrays for any (odd) dimension, initial direction (up, down, left, right) and direction (clockwise/anticlockwise).

I haven't replaced any of the code that uses the hard coded spirals yet, but I figure this can come later?

I'm not sure if this belongs in the `_util` or `preprocess` modules? I thought `_util` seemed more appropriate seeing as it's not used directly for preprocessing images.
