### PR TITLE
Add imageXpress screens module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
     - py.test
 
 after_success:
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]]; then coveralls; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then coveralls; fi
 
 before_cache:
 # clean unused packages & installed files from conda cache

--- a/microscopium/_util.py
+++ b/microscopium/_util.py
@@ -87,5 +87,6 @@ def int_or_none(n):
     --------
     >>> int_or_none(3.0)
     3
+    >>> int_or_none(None)
     """
     return int(n) if n is not None else None

--- a/microscopium/_util.py
+++ b/microscopium/_util.py
@@ -1,6 +1,7 @@
 import numpy as np
 import numbers
 
+
 def groupby(key, iterable, transform=None):
     """Group items in `iterable` in a dictionary according to `key`.
 
@@ -66,3 +67,25 @@ def normalise_random_state(seed):
         return seed
     else:
         raise ValueError('Invalid input %s to generate random state' % seed)
+
+
+def int_or_none(n):
+    """Returns input n cast as int, or None if input is none.
+
+    This is used in parsing sample information from image filenames.
+
+    Parameters
+    ----------
+    n : any value castable as int, None
+        The input value.
+
+    Returns
+    -------
+    The input value cast an int, or None.
+
+    Examples
+    --------
+    >>> int_or_none(3.0)
+    3
+    """
+    return int(n) if n is not None else None

--- a/microscopium/screens/__init__.py
+++ b/microscopium/screens/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from . import myores, cellomics, image_xpress
 
-__all__ = ['myores', 'cellomics', 'image_express']
+__all__ = ['myores', 'cellomics', 'image_xpress']
 
 d = {'myores': {'index': myores.filename2id,
                    'fmap':  myores.feature_map},

--- a/microscopium/screens/__init__.py
+++ b/microscopium/screens/__init__.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
-from . import myores, cellomics
+from . import myores, cellomics, image_xpress
 
-__all__ = ['myores', 'cellomics']
+__all__ = ['myores', 'cellomics', 'image_express']
 
 d = {'myores': {'index': myores.filename2id,
                    'fmap':  myores.feature_map},
      'cellomics': {'index': cellomics.filename2id,
-                   'fmap':  cellomics.feature_map}
+                   'fmap':  cellomics.feature_map},
+     'image-xpress': {'index': image_xpress.filename2id,
+                      'fmap': image_xpress.feature_map}
     }
 

--- a/microscopium/screens/cellomics.py
+++ b/microscopium/screens/cellomics.py
@@ -14,6 +14,7 @@ from .. import features as feat
 from six.moves import range
 from six.moves import zip
 import re
+from .. import _util
 
 
 SPIRAL_CLOCKWISE_RIGHT_25 = [[20, 21, 22, 23, 24],
@@ -221,9 +222,8 @@ def cellomics_semantic_filename(fn):
     fn_regex = re.search(r'(\w+)_(\w+)_([A-P]\d+)f?(\d+)?d?(\d+)?', fn)
     prefix, plate, well, field, channel = map(lambda x:
                                               fn_regex.group(x), range(1, 6))
-    def int_or_none(n): return int(n) if n is not None else None
     values = [directory, prefix, int(plate), well,
-              int_or_none(field), int_or_none(channel), suffix]
+              _util.int_or_none(field), _util.int_or_none(channel), suffix]
     semantic = coll.OrderedDict(list(zip(keys, values)))
 
     return semantic

--- a/microscopium/screens/image_xpress.py
+++ b/microscopium/screens/image_xpress.py
@@ -5,6 +5,7 @@ import os
 import collections as coll
 import re
 from .. import features as feat
+from .. import _util
 
 
 def ix_semantic_filename(fn):
@@ -22,10 +23,8 @@ def ix_semantic_filename(fn):
     well, field, channel = map(lambda x: fn_regex.group(x), range(1, 4))
     plate = int(dir_regex.group(1))
 
-    def int_or_none(n): return int(n) if n is not None else None
-
     values = [directory, prefix, int(plate), well,
-              int_or_none(field), int_or_none(channel), suffix]
+              _util.int_or_none(field), _util.int_or_none(channel), suffix]
 
     semantic = coll.OrderedDict(zip(keys, values))
 

--- a/microscopium/screens/image_xpress.py
+++ b/microscopium/screens/image_xpress.py
@@ -14,13 +14,12 @@ def ix_semantic_filename(fn):
     directory, fn = os.path.split(fn)
     fn, suffix = fn.split('.', 1)
 
-    # no prefixes in ix filenames, so just use an empty string
-    prefix = ''
+    fn_regex = re.search(r'([^\W_]{0,})(?:_{0,})([A-P]\d+)_s(\d+)_w(\d{1})',
+                         fn)
+    # finds last set of contiguous digits after underscore
+    dir_regex = re.search(r'_(\d+)(?!.*_(\d+))', directory)
 
-    fn_regex = re.search(r'([A-P]\d+)_s(\d+)_w(\d{1})', fn)
-    dir_regex = re.search(r'.*(?:\D|^)(\d+)', directory)
-
-    well, field, channel = map(lambda x: fn_regex.group(x), range(1, 4))
+    prefix, well, field, channel = map(lambda x: fn_regex.group(x), range(1, 5))
     plate = int(dir_regex.group(1))
 
     values = [directory, prefix, int(plate), well,

--- a/microscopium/screens/image_xpress.py
+++ b/microscopium/screens/image_xpress.py
@@ -9,7 +9,20 @@ from .. import _util
 
 
 def ix_semantic_filename(fn):
-    keys = ['directory', 'prefix', 'plate', 'well', 'field', 'channel', 'suffix']
+    """Split an ImageXpress filename into its annotated components.
+
+    Parameters
+    ----------
+    fn : string
+        A filename from the ImageXpress high-content screening system.
+
+    Returns
+    -------
+    semantic : collections.OrderedDict {string: string}
+        A dictionary mapping the different components of the filename.
+    """
+    keys = ['directory', 'prefix', 'plate', 'well', 'field', 'channel',
+            'suffix']
 
     directory, fn = os.path.split(fn)
     fn, suffix = fn.split('.', 1)
@@ -19,7 +32,8 @@ def ix_semantic_filename(fn):
     # finds last set of contiguous digits after underscore
     dir_regex = re.search(r'_(\d+)(?!.*_(\d+))', directory)
 
-    prefix, well, field, channel = map(lambda x: fn_regex.group(x), range(1, 5))
+    prefix, well, field, channel = map(lambda x: fn_regex.group(x),
+                                       range(1, 5))
     plate = int(dir_regex.group(1))
 
     values = [directory, prefix, int(plate), well,

--- a/microscopium/screens/image_xpress.py
+++ b/microscopium/screens/image_xpress.py
@@ -1,0 +1,90 @@
+"""Feature computations and other functions for Image Xpress screens
+"""
+
+import os
+import collections as coll
+import re
+from .. import features as feat
+
+
+def ix_semantic_filename(fn):
+    keys = ['directory', 'prefix', 'plate', 'well', 'field', 'channel', 'suffix']
+
+    directory, fn = os.path.split(fn)
+    fn, suffix = fn.split('.', 1)
+
+    # no prefixes in ix filenames, so just use an empty string
+    prefix = ''
+
+    fn_regex = re.search(r'([A-P]\d+)_s(\d+)_w(\d{1})', fn)
+    dir_regex = re.search(r'.*(?:\D|^)(\d+)', directory)
+
+    well, field, channel = map(lambda x: fn_regex.group(x), range(1, 4))
+    plate = int(dir_regex.group(1))
+
+    def int_or_none(n): return int(n) if n is not None else None
+
+    values = [directory, prefix, int(plate), well,
+              int_or_none(field), int_or_none(channel), suffix]
+
+    semantic = coll.OrderedDict(zip(keys, values))
+
+    # molecular devices 1-index their channel and field values,
+    # subtract 1 if these fields exist
+    for key in ["channel", "field"]:
+        if semantic[key] is not None:
+            semantic[key] -= 1
+
+    return semantic
+
+
+def filename2coord(fn):
+    """Obtain (plate, well) coordinates from a filename.
+
+    Parameters
+    ----------
+    fn : string
+        The input filename. This must include a directory with the
+        the plate number has these aren't coded in IX files.
+
+    Returns
+    -------
+    coord : (int, string, int) tuple
+        The (plate, well, cell) coordinates of the image.
+
+    Examples
+    --------
+    >>> fn = "./Week1_22123/G10_s2_w11C3B9BCC-E48F-4C2F-9D31-8F46D8B5B972.tif"
+    >>> filename2coord(fn)
+    (22123, 'G10')
+    """
+    sem = ix_semantic_filename(fn)
+    return sem["plate"], sem["well"]
+
+
+def filename2id(fn):
+    """Get a mongo ID, string representation of (plate, well), from filename.
+
+    Parameters
+    ----------
+    fn : string
+        Filename of a standard Image Xpress screen image. This must include
+        the directory with plate number.
+
+    Returns
+    -------
+    id_ : string
+        The mongo ID.
+
+    Examples
+    --------
+    >>> fn = "./Week4_27481/Week1_22123/G10_s2_w11C3B9BCC-"\
+    "E48F-4C2F-9D31-8F46D8B5B972.tif"
+    >>> filename2id(fn)
+    '22123-G10'
+    """
+    from .myores import key2mongo
+    id_ = key2mongo(filename2coord(fn))
+    return id_
+
+feature_map = feat.default_feature_map

--- a/tests/test_image_xpress.py
+++ b/tests/test_image_xpress.py
@@ -14,3 +14,16 @@ def test_ix_semantic_filename():
 
     assert image_xpress.ix_semantic_filename(test_fn) == expected
 
+
+def test_ix_semantic_filename2():
+    test_fn = "./BBBC022_v1_images_20585w1/IXMtest_L09_s3_w1538679C9-F03A-" \
+              "4656-9A57-0D4A440C1C62.tif"
+    expected = coll.OrderedDict([('directory', './BBBC022_v1_images_20585w1'),
+                                 ('prefix', 'IXMtest'),
+                                 ('plate', 20585),
+                                 ('well', 'L09'),
+                                 ('field', 2),
+                                 ('channel', 0),
+                                 ('suffix', 'tif')])
+    assert image_xpress.ix_semantic_filename(test_fn) == expected
+

--- a/tests/test_image_xpress.py
+++ b/tests/test_image_xpress.py
@@ -1,0 +1,16 @@
+from microscopium.screens import image_xpress
+import collections as coll
+
+
+def test_ix_semantic_filename():
+    test_fn = "./Week1_22123/G10_s2_w11C3B9BCC-E48F-4C2F-9D31-8F46D8B5B972.tif"
+    expected = coll.OrderedDict([('directory', './Week1_22123'),
+                            ('prefix', ''),
+                            ('plate', 22123),
+                            ('well', 'G10'),
+                            ('field', 1),
+                            ('channel', 0),
+                            ('suffix', 'tif')])
+
+    assert image_xpress.ix_semantic_filename(test_fn) == expected
+


### PR DESCRIPTION
This PR adds a module to ``screens`` for reading HCS images using the Molecular Devices ImageXpress system. I've been using these functions to handle the BBBC021/BBBC022 data.