### PR TITLE
Add function to support montaging when fields are missing

### DIFF
--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -833,9 +833,8 @@ def find_missing_fields(fns, order=None,
 
     Returns
     -------
-    missing : list of int
-        Returns an empty list where no fields were determined
-        missing, otherwise a list of the missing fields.
+    missing : array of int
+        A possibly empty array containing the indices of missing fields.
     """
     if order is None:
         from .screens import cellomics

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -890,13 +890,15 @@ def create_missing_mask(missing, order, rows=512, cols=512):
 
 
 def montage_with_missing(fns, order=None):
-    """Montage a list of images, replacing missing fields with dummy images.
+    """Montage a list of images, replacing missing fields with dummy values.
 
     The methods `montage` and `montage_stream` assume that image filenames
     and image iterators passed to it are complete, and include the full set
     images belonging to the well. Some screens have missing fields,
     so this function can be used to montage together images with missing
-    fields. Missing fields are determined from the information in the image
+    fields. Missing fields are replaced with 0 values.
+
+    Missing fields are determined from the information in the image
     file name. See 'find_missing_fields'
 
     Parameters
@@ -906,6 +908,7 @@ def montage_with_missing(fns, order=None):
     order : array-like of int, shape (M, N), optional
         The order of the stitching, with each entry referring
         to the index of file in the fns array.
+        Default cellomics.SPIRAL_CLOCKWISE_RIGHT_25
 
     Returns
     -------

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -846,9 +846,7 @@ def find_missing_fields(fns, order=None,
     fields = [int(re.match(pattern, fn).group(re_group)) for fn in fns]
 
     # determine which fields are missing
-    start, end = np.min(order), np.max(order)
-    missing = sorted(set(range(start, end + 1)).difference(fields))
-
+    missing = np.setdiff1d(order, fields)
     return missing
 
 

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -955,12 +955,9 @@ def montage_with_missing(fns, order=None):
     for i, j in it.product(range(mrows), range(mcols)):
         index = order[i, j]
 
-        if _fns[index] is None:
-            im = np.zeros((rows, cols), dtype=im0.dtype)
-        else:
+        if _fns[index] is not None:
             im = io.imread(_fns[index])
-
-        montaged[rows*i:rows*(i+1), cols*j:cols*(j+1)] = im
+            montaged[rows*i:rows*(i+1), cols*j:cols*(j+1)] = im
 
     return montaged, mask, len(missing)
 

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -871,6 +871,11 @@ def create_missing_mask(missing, order, rows=512, cols=512):
         The number of rows in the input images. Default 512.
     cols : int, optional
         The number of cols in the input images. Default 512.
+
+    Returns
+    -------
+    mask : array of bool, shape (P, Q)
+        A binary mask where False denotes a missing field.
     """
     if order is None:
         from .screens import cellomics
@@ -914,7 +919,7 @@ def montage_with_missing(fns, order=None):
     -------
     montaged : array-like, shape (P, Q)
         The montaged image.
-    mask : array of bool
+    mask : array of bool, shape (P, Q)
         A binary mask, where entries with taking the value of
         False represent missing fields in the montaged image.
     missing : int

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -809,7 +809,7 @@ def montage(ims, order=None):
 
 
 def find_missing_fields(fns, order=None,
-                        re_string=".*_[A-P]\d{2}f(\d{2})d0",
+                        re_string=r".*_[A-P]\d{2}f(\d{2})d0",
                         re_group=1):
     """Find which fields are missing from a list of files belonging to a well.
 

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -889,6 +889,76 @@ def create_missing_mask(missing, order, rows=512, cols=512):
     return mask
 
 
+def montage_with_missing(fns, order=None):
+    """Montage a list of images, replacing missing fields with dummy images.
+
+    The methods `montage` and `montage_stream` assume that image filenames
+    and image iterators passed to it are complete, and include the full set
+    images belonging to the well. Some screens have missing fields,
+    so this function can be used to montage together images with missing
+    fields. Missing fields are determined from the information in the image
+    file name. See 'find_missing_fields'
+
+    Parameters
+    ----------
+    fns : list of str
+        The list of filenames to montage.
+    order : array-like of int, shape (M, N), optional
+        The order of the stitching, with each entry referring
+        to the index of file in the fns array.
+
+    Returns
+    -------
+    montaged : array-like, shape (P, Q)
+        The montaged image.
+    mask : array of bool
+        A binary mask, where entries with taking the value of
+        False represent missing fields in the montaged image.
+    missing : int
+        The number of fields that were found to be missing in the
+        input list of filenames. This is useful for normalising
+        features that depend on the entirety of the montaged image
+        (e.g. count of objects).
+    """
+    if order is None:
+        from .screens import cellomics
+        order = cellomics.SPIRAL_CLOCKWISE_RIGHT_25
+    order = np.atleast_2d(order)
+    mrows, mcols = order.shape
+
+    # get width & height of first image. the rest of the images
+    # are assumed to be of the same shape
+    im0 = io.imread(fns[0])
+    rows, cols = im0.shape[:2]
+
+    # find which fields are missing
+    missing = find_missing_fields(fns, order)
+
+    # insert None value to list of files when fields missing
+    _fns = fns[:]  # create copy of list to avoid referencing problems
+    for i in missing:
+        _fns.insert(i, None)
+
+    # create binary mask for the missing fields
+    mask = create_missing_mask(missing, order, rows, cols)
+
+    # instantiate array for output montaged image
+    montaged = np.zeros((rows * mrows, cols * mcols) + im0.shape[2:],
+                        dtype=im0.dtype)
+
+    for i, j in it.product(range(mrows), range(mcols)):
+        index = order[i, j]
+
+        if _fns[index] is None:
+            im = np.zeros((rows, cols), dtype=im0.dtype)
+        else:
+            im = io.imread(_fns[index])
+
+        montaged[rows*i:rows*(i+1), cols*j:cols*(j+1)] = im
+
+    return montaged, mask, len(missing)
+
+
 @tlz.curry
 def reorder(index_list, list_to_reorder):
     """Curried function to reorder a list according to input indices.

--- a/tests/test_pre.py
+++ b/tests/test_pre.py
@@ -128,5 +128,25 @@ def test_find_missing_fields(fns, expected):
     assert actual == expected
 
 
+missing_mask_test = [
+    ([], [[0, 1, 2]], 10, 5, np.ones((10, 15), dtype=np.bool)),
+    ([0, 5], [[0, 1, 2], [4, 5, 6]], 5, 10, np.ones((10, 30), dtype=np.bool)),
+    ([3, 4], [[0, 1], [2, 3], [4, 5]], 10, 5, np.ones((30, 10), dtype=np.bool))
+]
+
+# insert False to missing areas of expected output
+missing_mask_test[1][4][0:5, 0:10] = False
+missing_mask_test[1][4][5:10, 10:20] = False
+
+missing_mask_test[2][4][10:20, 5:10] = False
+missing_mask_test[2][4][20:30, 0:5] = False
+
+
+@pytest.mark.parametrize("missing, order, rows, cols, expected",
+                         missing_mask_test)
+def test_create_missing_mask(missing, order, rows, cols, expected):
+    actual = pre.create_missing_mask(missing, order, rows, cols)
+    np.testing.assert_array_equal(actual, expected)
+
 if __name__ == '__main__':
     pytest.main()

--- a/tests/test_pre.py
+++ b/tests/test_pre.py
@@ -109,5 +109,24 @@ def test_correct_multiimage_illum(image_files_noise):
         assert np.median(k) > 100
 
 
+cellomics_pattern = "MFGTMP_150406100001_A01f{0:02d}d0.TIF"
+
+missing_test_fns = [
+    ([cellomics_pattern.format(i) for i in range(25)], []),
+    ([cellomics_pattern.format(i) for i in range(25)], [1, 13])
+]
+
+# delete "images" with fields 1 and 13 from second set of
+# image filesnames
+missing_test_fns[1][0].remove(cellomics_pattern.format(1))
+missing_test_fns[1][0].remove(cellomics_pattern.format(13))
+
+
+@pytest.mark.parametrize("fns, expected", missing_test_fns)
+def test_find_missing_fields(fns, expected):
+    actual = pre.find_missing_fields(fns)
+    assert actual == expected
+
+
 if __name__ == '__main__':
     pytest.main()

--- a/tests/test_pre.py
+++ b/tests/test_pre.py
@@ -129,6 +129,9 @@ def test_find_missing_fields(fns, expected):
     np.testing.assert_array_equal(actual, expected)
 
 
+# create a list of parameters for testing the create missing mask files
+# each entry in the tuple represents the fields: missing, order, rows, cols
+# and expected (the expected output from the function)
 missing_mask_test = [
     ([], [[0, 1, 2]], 10, 5, np.ones((10, 15), dtype=np.bool)),
     ([0, 5], [[0, 1, 2], [4, 5, 6]], 5, 10, np.ones((10, 30), dtype=np.bool)),
@@ -143,6 +146,9 @@ missing_mask_test[2][4][10:20, 5:10] = False
 missing_mask_test[2][4][20:30, 0:5] = False
 
 
+# pass the set of list parameters to the test_create_missing_mask
+# function. the test wil run against every of parameters in the
+# missing_mask_test list
 @pytest.mark.parametrize("missing, order, rows, cols, expected",
                          missing_mask_test)
 def test_create_missing_mask(missing, order, rows, cols, expected):

--- a/tests/test_pre.py
+++ b/tests/test_pre.py
@@ -126,7 +126,7 @@ missing_test_fns[1][0].remove(cellomics_pattern.format(13))
 @pytest.mark.parametrize("fns, expected", missing_test_fns)
 def test_find_missing_fields(fns, expected):
     actual = pre.find_missing_fields(fns)
-    assert actual == expected
+    np.testing.assert_array_equal(actual, expected)
 
 
 missing_mask_test = [

--- a/tests/test_pre.py
+++ b/tests/test_pre.py
@@ -180,7 +180,7 @@ def test_image_files_montage(request):
     return make_test_montage_files
 
 
-def test_montage_with_missing_montage(test_image_files_montage):
+def test_montage_with_missing(test_image_files_montage):
     files = test_image_files_montage(missing_fields=[20])
     montage, mask, number_missing = pre.montage_with_missing(files)
 


### PR DESCRIPTION
This adds the ``montage_with_missing`` function that takes a list of files, a regex pattern to find the field number and a stitching order. The function returns the montaged images, a binary mask where ``False`` values represent missing fields in the montaged image, and the number of missing fields. 

I've not added this function to the command line (yet) as it would require some pretty significant re-writing of the command-line code that I'd rather not spend time on right now. I'm happy to add this as an outstanding issue once merged though. But the function will be tested and available in the API!:)