### PR TITLE
Add new background illumination methods

### DIFF
--- a/microscopium/main.py
+++ b/microscopium/main.py
@@ -129,6 +129,8 @@ illum.add_argument('-L', '--stretchlim-output', metavar='[0.0-1.0]', type=float,
 illum.add_argument('-q', '--quantile', metavar='[0.0-1.0]', type=float,
                    default=0.05,
                    help='Use this quantile to determine illumination.')
+illum.add_argument('-i', '--input-bitdepth', type=int, default=None,
+                   help='Input bit-depth of images.')
 illum.add_argument('-r', '--radius', metavar='INT', type=int, default=51,
                    help='Radius in which to find quantile.')
 illum.add_argument('-s', '--save-illumination', metavar='FN',
@@ -153,9 +155,9 @@ def run_illum(args):
     """
     if args.file_list is not None:
         args.images.extend([fn.rstrip() for fn in args.file_list])
-    il = pre.find_background_illumination(args.images, args.radius,
-                                          args.quantile, args.stretchlim,
-                                          args.method)
+    il = pre.find_background_illumination(args.images, args.input_bitdepth,
+                                          args.radius, args.quantile,
+                                          args.stretchlim, args.method)
     if args.verbose:
         print('illumination field:', type(il), il.dtype, il.min(), il.max())
     if args.save_illumination is not None:

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -514,7 +514,7 @@ def _reduce_with_count(pairwise, iterator, accumulator=None):
     return tlz.reduce(new_pairwise, new_iter, new_acc)
 
 
-def find_background_illumination(fns, radius=None, input_bitdepth=None,
+def find_background_illumination(fns, input_bitdepth=None, radius=None,
                                  quantile=0.5, stretch_quantile=0.,
                                  method='mean'):
     """Use a set of related images to find uneven background illumination.
@@ -523,6 +523,10 @@ def find_background_illumination(fns, radius=None, input_bitdepth=None,
     ----------
     fns : list of string
         A list of image file names
+    input_bitdepth : int, optional
+        The bit-depth of the input images. Should be specified if non-standard
+        bitdepth images are used in a 16-bit image file, e.g. 12-bit images.
+        Default is the dtype of the input image.
     radius : int, optional
         The radius of the structuring element used to find background.
         default: The width or height of the input images divided by 4,

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -632,8 +632,10 @@ def correct_multiimage_illumination(im_fns, illum, stretch_quantile=0,
 
     Returns
     -------
-    ims_out : iterable of corrected uint8 images
+    ims_out : iterable of corrected images.
         The images corrected for background illumination.
+        The dtype of the output images is determined by the dtype
+        of the first image passed to the function.
 
     References
     ----------
@@ -642,6 +644,9 @@ def correct_multiimage_illumination(im_fns, illum, stretch_quantile=0,
     p0 = 100 * stretch_quantile
     p1 = 100 - p0
     im_fns = list(im_fns)
+
+    # read first image to get input image dtypes
+    im0 = mio.imread(im_fns[0])
 
     # in first pass, make a composite image to get global intensity range
     ims_pass1 = map(io.imread, im_fns)
@@ -654,8 +659,8 @@ def correct_multiimage_illumination(im_fns, illum, stretch_quantile=0,
     for im in ims_pass2:
         corrected = im / illum
         rescaled = exposure.rescale_intensity(corrected, in_range=corr_range,
-                                              out_range=np.uint8)
-        out = np.round(rescaled).astype(np.uint8)
+                                              out_range=im0.dtype.type)
+        out = np.round(rescaled).astype(im0.dtype)
         yield out
 
 

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -6,7 +6,7 @@ import collections as coll
 import re
 import numpy as np
 from scipy import ndimage as nd
-from skimage import io
+from skimage import io, util, img_as_float, img_as_uint
 from scipy.stats.mstats import mquantiles as quantiles
 from skimage import morphology as skmorph, filters as imfilter, exposure
 import skimage.filters.rank as rank
@@ -14,6 +14,7 @@ import skimage
 import cytoolz as tlz
 from cytoolz import curried
 from six.moves import map, range, zip, filter
+import warnings
 
 from ._util import normalise_random_state
 from . import io as mio
@@ -513,8 +514,9 @@ def _reduce_with_count(pairwise, iterator, accumulator=None):
     return tlz.reduce(new_pairwise, new_iter, new_acc)
 
 
-def find_background_illumination(fns, radius=51, quantile=0.05,
-                                 stretch_quantile=0., method='mean'):
+def find_background_illumination(fns, radius=None, input_bitdepth=None,
+                                 quantile=0.5, stretch_quantile=0.,
+                                 method='mean'):
     """Use a set of related images to find uneven background illumination.
 
     Parameters
@@ -523,14 +525,16 @@ def find_background_illumination(fns, radius=51, quantile=0.05,
         A list of image file names
     radius : int, optional
         The radius of the structuring element used to find background.
-        default: 51
+        default: The width or height of the input images divided by 4,
+        whichever is smaller.
     quantile : float in [0, 1], optional
         The desired quantile to find background. default: 0.05
     stretch_quantile : float in [0, 1], optional
         Stretch image to full dtype limit, saturating above this quantile.
     method : 'mean', 'average', 'median', or 'histogram', optional
-        How to use combine the smoothed intensities of the input images
-        to infer the illumination field:
+        How to use combine the related images. The output from this
+        combination is smoothed and is used to estimate the
+        illumination correction field.
 
         - 'mean' or 'average': Use the mean value of the smoothed
         images at each pixel as the illumination field.
@@ -549,39 +553,58 @@ def find_background_illumination(fns, radius=51, quantile=0.05,
     --------
     `correct_image_illumination`, `correct_multiimage_illumination`.
     """
-    # This function follows the "PyToolz" streaming data model to
-    # obtain the illumination estimate. First, define each processing
-    # step:
-    read = io.imread
+    read = tlz.partial(io.imread)
+
+    if input_bitdepth is None:
+        in_range = "image"
+    else:
+        in_range = (0, np.power(2, input_bitdepth) - 1)
+
+    if radius is None:
+        # get default radius from input image
+        im0 = mio.imread(fns[0])
+        radius = np.round(np.min(im0.shape) / 4).astype(np.uint16)
+        # ensure radius is odd
+        radius = radius - np.mod(radius, 2) + 1
+
+    rescale = tlz.partial(exposure.rescale_intensity, in_range=in_range)
     normalize = (tlz.partial(stretchlim, bottom=stretch_quantile)
                  if stretch_quantile > 0
                  else skimage.img_as_float)
-    rescale = rescale_to_11bits
-    pad = fun.partial(skimage.util.pad, pad_width=radius, mode='reflect')
-    rank_filter = fun.partial(rank.percentile, selem=skmorph.disk(radius),
-                              p0=quantile)
-    _unpad = fun.partial(unpad, pad_width=radius)
-    unscale = rescale_from_11bits
 
-    # Next, compose all the steps, apply to all images (streaming)
-    bg = (tlz.pipe(fn, read, normalize, rescale, pad, rank_filter, _unpad,
-                   unscale)
-          for fn in fns)
+    ims = (tlz.pipe(fn, read, rescale, normalize) for fn in fns)
 
-    # Finally, reduce all the images and compute the estimate
-    if method == 'mean' or method == 'average':
-        illum, count = _reduce_with_count(np.add, bg)
-        illum = skimage.img_as_float(illum) / count
-    elif method == 'median':
-        illum = np.median(list(bg), axis=0)
-    elif method == 'histogram':
+    if method == "mean":
+        illum, count = _reduce_with_count(np.add, ims)
+        illum = illum / count
+    elif method == "median":
+        # TODO: support sub-sampling get estimate of median
+        illum = np.median(list(ims), axis=0)
+    elif method == "histogram":
         raise NotImplementedError('histogram background illumination method '
                                   'not yet implemented.')
     else:
         raise ValueError('Method "%s" of background illumination finding '
                          'not recognised.' % method)
 
-    return illum
+    # apply median filter to find ICF
+    pad = tlz.partial(util.pad, pad_width=radius, mode='reflect')
+    rank_filter = fun.partial(rank.percentile, selem=skmorph.disk(radius),
+                              p0=quantile)
+    _unpad = tlz.partial(unpad, pad_width=radius)
+
+    # ignore the loss of precision warning
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        # images are cast as uint16 to preserve the granularity
+        # of illumination values in the mean/median image.
+        # mean/median images with a small range can result in
+        # non-smooth ICFs which result in artefacts when the
+        # images are corrected
+        bg = tlz.pipe(illum, img_as_uint, pad, rank_filter, _unpad,
+                      img_as_float)
+
+    return bg
 
 
 def correct_multiimage_illumination(im_fns, illum, stretch_quantile=0,

--- a/tests/test_pre.py
+++ b/tests/test_pre.py
@@ -12,21 +12,21 @@ import warnings
 def image_files(request):
     # for clarity we define images as integer arrays in [0, 11) and
     # divide by 10 later
-    i = np.array([[ 7,  4,  1,  1,  0],
-                  [ 2,  5,  9,  6,  7],
-                  [ 2,  3,  3,  8,  5],
-                  [ 3,  0,  1,  7,  5],
-                  [ 6,  0, 10,  1,  6]], np.uint8)
-    j = np.array([[ 1, 10,  0,  9,  0],
-                  [ 3, 10,  4,  1,  1],
-                  [ 4, 10,  0,  7,  4],
-                  [ 9,  3,  2,  0,  7],
-                  [ 1,  3,  3,  9,  3]], np.uint8)
-    k = np.array([[ 9,  1,  7,  7,  3],
-                  [ 9,  1,  6,  2,  2],
-                  [ 2,  8,  2,  0,  3],
-                  [ 4,  3,  8,  9, 10],
-                  [ 6,  0,  2,  3, 10]], np.uint8)
+    i = np.array([[7, 4, 1, 1, 0],
+                  [2, 5, 9, 6, 7],
+                  [2, 3, 3, 8, 5],
+                  [3, 0, 1, 7, 5],
+                  [6, 0, 10, 1, 6]], np.uint8)
+    j = np.array([[1, 10, 0, 9, 0],
+                  [3, 10, 4, 1, 1],
+                  [4, 10, 0, 7, 4],
+                  [9, 3, 2, 0, 7],
+                  [1, 3, 3, 9, 3]], np.uint8)
+    k = np.array([[9, 1, 7, 7, 3],
+                  [9, 1, 6, 2, 2],
+                  [2, 8, 2, 0, 3],
+                  [4, 3, 8, 9, 10],
+                  [6, 0, 2, 3, 10]], np.uint8)
     files = []
     for im in [i, j, k]:
         f, fn = tempfile.mkstemp(suffix='.png')
@@ -46,11 +46,11 @@ def test_illumination_mean(image_files):
                                              quantile=0.5,
                                              stretch_quantile=1e-7,
                                              method='mean')
-    illum_true = np.array([[5.33, 5.33, 4.67, 1.67, 1.67],
-                           [3.67, 6.67, 2.67, 4.33, 3.00],
-                           [6.67, 3.00, 4.33, 3.00, 5.33],
-                           [2.67, 2.67, 2.67, 6.67, 6.00],
-                           [3.33, 2.00, 2.33, 6.33, 7.33]]) / 10
+    illum_true = np.array([[5., 5.33, 5.67, 3., 3.33],
+                           [5.33, 5.33, 3., 5., 3.],
+                           [5.33, 2.67, 5., 4., 5.],
+                           [2.67, 3.67, 3.67, 5., 5.33],
+                           [4.33, 2., 3.67, 5.33, 6.33]]) / 10
     np.testing.assert_array_almost_equal(illum, illum_true, decimal=1)
 
 
@@ -59,11 +59,11 @@ def test_illumination_median(image_files):
                                              quantile=0.5,
                                              stretch_quantile=1e-7,
                                              method='median')
-    illum_true = np.array([[ 4.,  5.,  4.,  1.,  1.],
-                           [ 4.,  6.,  2.,  4.,  2.],
-                           [ 8.,  3.,  4.,  2.,  7.],
-                           [ 3.,  3.,  3.,  7.,  6.],
-                           [ 3.,  3.,  3.,  7.,  7.]]) / 10
+    illum_true = np.array([[4., 5., 6., 2., 2.],
+                           [5., 5., 2., 6., 2.],
+                           [4., 3., 6., 4., 7.],
+                           [3., 3., 3., 7., 7.],
+                           [4., 3., 2., 6., 6.]]) / 10
     np.testing.assert_array_almost_equal(illum, illum_true, decimal=1)
 
 


### PR DESCRIPTION
This PR adds fast illumination method used by Broad [[1](http://onlinelibrary.wiley.com/doi/10.1111/jmi.12178/full)] for their images, and better handles images with non-standard bitdepths in 16-bit containers. The new background illumination method find the median filtered version of the mean image, rather than finding the mean of a the median filtered images. This speeds things up significantly.
- `find_background_illumination` now finds the illumination correction field by finding the mean of the related images, then smoothing that out with a rank filter. Default parameter for the filter is p0=0.5 (i.e. a median filter).
- `find_background_illumination` now takes an input bit-depth parameter. This should be used when bit-depths of 12 or 14 bits were captuted by the camera, but a 16-bit TIF is used as a container. This ensures the original bit-depth is preserved in any subsequent steps of the illumination correction. 
- `find_background_illumination` has a default radius of one quarter the width or height the first image, whichever is smaller. After lots of experimentation with BBBC021, BBBC022 and the Cellomics data, I found this rule of thumb gave the best smooth illumination correction field across all channels. It's probably something that needs to be tweaked for every data-set but I'm happy with this default.
- `find_background_illumination` scales images from floats to `uint16` before being passed to the percentile filter. In the case where the mean image had a very limited dynamic range, the resultant smoothed, floating poiint image had quite a large granularity between values. This resulted in artefacts being added to the image during illumination correction. This makes rank filtering slower, but it doesn't matter because this PR reduces the number of rank filterings being done by several orders of magnitude. :)
- `correct_multiimage_illumination` no longer scales all images down to 8-bit, the dtype is now taken from the first image passed to the function. 
