### PR TITLE
Switch illum filtering from ndi percentile filter to SciKit image rank filter

### DIFF
--- a/microscopium/bokeh_app.py
+++ b/microscopium/bokeh_app.py
@@ -90,7 +90,7 @@ def update_image_canvas_multi(indices, data, source, max_images=25):
     filenames = data['path'].iloc[indices]
     if n_images > max_images:
         filenames = filenames[:max_images - 1]
-    images = [io.imread(fn) for fn in filenames]
+    images = [imread(fn) for fn in filenames]
     if n_images > max_images:
         # from the My First Pixel Art (TM) School of Design
         dotdotdot = np.full((7, 7, 4), 255, dtype=np.uint8)

--- a/microscopium/bokeh_app.py
+++ b/microscopium/bokeh_app.py
@@ -90,7 +90,7 @@ def update_image_canvas_multi(indices, data, source, max_images=25):
     filenames = data['path'].iloc[indices]
     if n_images > max_images:
         filenames = filenames[:max_images - 1]
-    images = [imread(fn) for fn in filenames]
+    images = [io.imread(fn) for fn in filenames]
     if n_images > max_images:
         # from the My First Pixel Art (TM) School of Design
         dotdotdot = np.full((7, 7, 4), 255, dtype=np.uint8)

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -592,8 +592,14 @@ def find_background_illumination(fns, radius=None, input_bitdepth=None,
 
     # return the median filter of that mean
     radius = radius or min(mean_image.shape) // 4
-    illum = ndi.percentile_filter(mean_image, percentile=(quantile * 100),
-                                  footprint=morphology.disk(radius))
+
+    # TODO: examine min & max, look at mean_image before and after img_as_uint, look at number of unique values
+    # TODO: want to see substantial range in the result
+    mean_image = img_as_uint(stretchlim(mean_image))
+    illum = imfilter.rank.median(mean_image, selem=morphology.disk(radius))
+
+    # illum = ndi.percentile_filter(mean_image, percentile=(quantile * 100),
+    #                               footprint=morphology.disk(radius))
     return illum
 
 

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -6,7 +6,7 @@ import re
 import numpy as np
 from scipy import ndimage as ndi
 from scipy.stats.mstats import mquantiles as quantiles
-from skimage import io, util, img_as_float, img_as_uint
+from skimage import io, util, img_as_float, img_as_ubyte
 from skimage import morphology, filters as imfilter, exposure
 import skimage.filters.rank as rank
 import skimage
@@ -595,7 +595,7 @@ def find_background_illumination(fns, radius=None, input_bitdepth=None,
 
     # TODO: examine min & max, look at mean_image before and after img_as_uint, look at number of unique values
     # TODO: want to see substantial range in the result
-    mean_image = img_as_uint(stretchlim(mean_image))
+    mean_image = img_as_ubyte(stretchlim(mean_image))
     illum = imfilter.rank.median(mean_image, selem=morphology.disk(radius))
     return illum
 

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -593,8 +593,6 @@ def find_background_illumination(fns, radius=None, input_bitdepth=None,
     # return the median filter of that mean
     radius = radius or min(mean_image.shape) // 4
 
-    # TODO: examine min & max, look at mean_image before and after img_as_uint, look at number of unique values
-    # TODO: want to see substantial range in the result
     mean_image = img_as_ubyte(stretchlim(mean_image))
     illum = imfilter.rank.median(mean_image, selem=morphology.disk(radius))
     return illum

--- a/microscopium/preprocess.py
+++ b/microscopium/preprocess.py
@@ -597,9 +597,6 @@ def find_background_illumination(fns, radius=None, input_bitdepth=None,
     # TODO: want to see substantial range in the result
     mean_image = img_as_uint(stretchlim(mean_image))
     illum = imfilter.rank.median(mean_image, selem=morphology.disk(radius))
-
-    # illum = ndi.percentile_filter(mean_image, percentile=(quantile * 100),
-    #                               footprint=morphology.disk(radius))
     return illum
 
 

--- a/tests/test_pre.py
+++ b/tests/test_pre.py
@@ -41,11 +41,11 @@ def image_files():
 def test_illumination_mean(image_files):
     illum = pre.find_background_illumination(image_files, radius=1,
                                              quantile=0.5)
-    illum_true = np.array([[5.67, 5.  , 5.  , 3.  , 1.  ],
-                           [4.67, 5.33, 3.  , 5.  , 3.33],
-                           [4.67, 2.67, 5.  , 4.  , 4.  ],
-                           [4.33, 3.67, 3.67, 5.  , 6.33],
-                           [4.33, 2.  , 4.33, 5.  , 6.33]]) / 10
+    illum_true = np.array([[161, 174, 188,  81,  94],
+                           [174, 174,  81, 161,  94],
+                           [174,  67, 161, 121, 161],
+                           [134, 107, 107, 161, 215],
+                           [134, 134, 134, 174, 215]], np.uint8)
     np.testing.assert_array_almost_equal(illum, illum_true, decimal=1)
 
 


### PR DESCRIPTION
Ndi percentile filter causes memory error as a result of the very large (512px) radius used to filter which requires an 8*512^4 byte array in the SciPy implementation (https://github.com/scipy/scipy/issues/4878). 

Switching to use scikit image median rank filter which is optimised to remember values of already visited pixels. 