### PR TITLE
UI tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,21 @@ Unsupervised clustering and dataset exploration for high content screens.
 [![Coverage Status](https://img.shields.io/coveralls/microscopium/microscopium.svg)](https://coveralls.io/r/microscopium/microscopium?branch=master)
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/microscopium/microscopium?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-# License
+## License
 
 This project uses the 3-clause BSD license. See `LICENSE.txt`.
+
+## For developers
+We encourage pull requests - please get in touch if you think you might like to contribute.
+
+### Serving the web app locally
+
+To run the web app locally in your browser:
+`python microscopium/bokeh_app.py tests/testdata/images/data.csv`
+You should then be able to see the app in your web browser at:
+http://localhost:5000
+
+Additionally, you can specify the port number using -P
+`python microscopium/bokeh_app.oy tests/testdata/images/data.csv -P 5001`
+
+Which will run the web app locally at http://localhost:5001/

--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ Additionally, you can specify the port number using -P
 `python microscopium/bokeh_app.oy tests/testdata/images/data.csv -P 5001`
 
 Which will run the web app locally at http://localhost:5001/
+
+For more information, run `python microscopium/bokeh_app.py --help`
+

--- a/microscopium/bokeh_app.py
+++ b/microscopium/bokeh_app.py
@@ -147,10 +147,16 @@ def make_makedoc(filename):
                                          'dx': [], 'dy': []})
         tools_pca = [ResetTool(), PanTool(), WheelZoomTool(), TapTool(),
                      BoxSelectTool(), PolySelectTool(), UndoTool(), RedoTool()]
+        TOOLTIPS = [
+            ("index", "$index"),
+            ("info", "@info"),
+            ("url", "@url")
+        ]
         pca = figure(title='PCA',
                      x_range=[minx - 0.05 * rangex, maxx + 0.05 * rangex],
                      y_range=[miny - 0.05 * rangey, maxy + 0.05 * rangey],
-                     sizing_mode='scale_both', tools=tools_pca)
+                     sizing_mode='scale_both', tools=tools_pca,
+                     tooltips=TOOLTIPS)
         glyphs = pca.circle(source=source, x='x', y='y')
 
         tools_sel = [ResetTool(), PanTool(), WheelZoomTool(),

--- a/microscopium/bokeh_app.py
+++ b/microscopium/bokeh_app.py
@@ -180,7 +180,7 @@ def make_makedoc(filename):
 
         glyphs.data_source.on_change('selected', load_selected)
 
-        fig = row([pca, sel], sizing_mode="stretch_both")
+        fig = row([pca, sel], sizing_mode="scale_width")
         doc.title = 'Bokeh microscopium app'
         doc.add_root(fig)
 

--- a/microscopium/bokeh_app.py
+++ b/microscopium/bokeh_app.py
@@ -7,9 +7,10 @@ from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.plotting import figure, ColumnDataSource
 from bokeh.layouts import row
-from bokeh.models.tools import (ResetTool, PanTool, WheelZoomTool, TapTool,
-                                BoxSelectTool, PolySelectTool, UndoTool,
-                                RedoTool, HoverTool, BoxZoomTool)
+from bokeh.models.tools import (HoverTool, TapTool, PanTool,
+                                WheelZoomTool, BoxZoomTool,
+                                BoxSelectTool, PolySelectTool, LassoSelectTool,
+                                ResetTool, UndoTool, RedoTool)
 from skimage import io
 import pandas as pd
 
@@ -146,7 +147,8 @@ def make_makedoc(filename):
         image_holder = ColumnDataSource({'image': [], 'x': [], 'y': [],
                                          'dx': [], 'dy': []})
         tools_pca = [ResetTool(), PanTool(), WheelZoomTool(), TapTool(),
-                     BoxSelectTool(), PolySelectTool(), UndoTool(), RedoTool()]
+                     BoxSelectTool(), PolySelectTool(), LassoSelectTool(),
+                     UndoTool(), RedoTool()]
         TOOLTIPS = [
             ("index", "$index"),
             ("info", "@info"),

--- a/microscopium/bokeh_app.py
+++ b/microscopium/bokeh_app.py
@@ -9,7 +9,7 @@ from bokeh.plotting import figure, ColumnDataSource
 from bokeh.layouts import row
 from bokeh.models.tools import (ResetTool, PanTool, WheelZoomTool, TapTool,
                                 BoxSelectTool, PolySelectTool, UndoTool,
-                                RedoTool, HoverTool)
+                                RedoTool, HoverTool, BoxZoomTool)
 from skimage import io
 import pandas as pd
 
@@ -145,16 +145,19 @@ def make_makedoc(filename):
         source = ColumnDataSource(dataframe)
         image_holder = ColumnDataSource({'image': [], 'x': [], 'y': [],
                                          'dx': [], 'dy': []})
-        tools = [ResetTool(), PanTool(), WheelZoomTool(), TapTool(),
-                 BoxSelectTool(), PolySelectTool(), UndoTool(), RedoTool()]
+        tools_pca = [ResetTool(), PanTool(), WheelZoomTool(), TapTool(),
+                     BoxSelectTool(), PolySelectTool(), UndoTool(), RedoTool()]
         pca = figure(title='PCA',
                      x_range=[minx - 0.05 * rangex, maxx + 0.05 * rangex],
                      y_range=[miny - 0.05 * rangey, maxy + 0.05 * rangey],
-                     sizing_mode='scale_both', tools=tools)
+                     sizing_mode='scale_both', tools=tools_pca)
         glyphs = pca.circle(source=source, x='x', y='y')
 
+        tools_sel = [ResetTool(), PanTool(), WheelZoomTool(),
+                     BoxZoomTool(match_aspect=True),
+                     UndoTool(), RedoTool()]
         sel = figure(title='Selected image', x_range=[0, 1], y_range=[0, 1],
-                     sizing_mode='scale_both')
+                     sizing_mode='scale_both', tools=tools_sel)
         image_canvas = sel.image_rgba('image', 'x', 'y', 'dx', 'dy',
                                       source=image_holder)
 
@@ -169,7 +172,7 @@ def make_makedoc(filename):
 
         glyphs.data_source.on_change('selected', load_selected)
 
-        fig = row([pca, sel], sizing_mode='stretch_both')
+        fig = row([pca, sel])
         doc.title = 'Bokeh microscopium app'
         doc.add_root(fig)
 

--- a/microscopium/bokeh_app.py
+++ b/microscopium/bokeh_app.py
@@ -172,7 +172,7 @@ def make_makedoc(filename):
 
         glyphs.data_source.on_change('selected', load_selected)
 
-        fig = row([pca, sel])
+        fig = row([pca, sel], sizing_mode="stretch_both")
         doc.title = 'Bokeh microscopium app'
         doc.add_root(fig)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ sh
 coverage
 pytest-cov
 imageio
+pscript


### PR DESCRIPTION
- [x] Enforced a consistent aspect ratio when using the zoom tools on image plots.
- [x] Add instructions to README on running the web app locally (ie: not using `bokeh serve ...`) 
- [x]  Bokeh tooltips
- [ ] ~~Slider bar to control size of circle glyphs on PCA plot (might need to look into this more, will do it another day)~~