### PR TITLE
Fix gitter badge formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Unsupervised clustering and dataset exploration for high content screens.
 
 [![Build Status](https://travis-ci.org/microscopium/microscopium.svg?branch=master)](https://travis-ci.org/microscopium/microscopium)
 [![Coverage Status](https://img.shields.io/coveralls/microscopium/microscopium.svg)](https://coveralls.io/r/microscopium/microscopium?branch=master)
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/microscopium/microscopium?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/microscopium/microscopium?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 # License
 


### PR DESCRIPTION
What it says on the tin: fixes the formatting of the Gitter badge in the README.