### PR TITLE
[WIP] FEAT: Support for 3d image data

### DIFF
--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -429,10 +429,10 @@ def make_makedoc(filename, color_column=None):
         source.on_change('selected', load_selected)
 
         tap_callback = CustomJS(args=dict(url=url, source=table.source), code="""
-            setTimeout(myFunction, 2000);
             function myFunction() {
                 window.open(url);
             }
+            setTimeout(myFunction, 2000);
             """)
         taptool.callback = tap_callback
 

--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -381,9 +381,12 @@ def make_makedoc(filename, color_column=None):
     def makedoc(doc):
         source = ColumnDataSource(dataframe)
         embed = embedding(source, glyph_size=10, color_column=color_column)
+        taptool = embed.select(TapTool)[0]
         image_plot, image_holder = selected_images()
         table = empty_table(dataframe)
         controls = [button_save_table(table), button_print_page()]
+        url_base = "volume_preview.html"
+        url = "http://localhost:5007/" + url_base
 
         def load_selected(attr, old, new):
             """Update images and table to display selected data."""
@@ -396,8 +399,16 @@ def make_makedoc(filename, color_column=None):
                 update_image_canvas_multi(new.indices, data=dataframe,
                                           source=image_holder)
             update_table(new.indices, dataframe, table)
-
         source.on_change('selected', load_selected)
+
+        tap_callback = CustomJS(args=dict(url=url, source=table.source), code="""
+            setTimeout(myFunction, 2000);
+            function myFunction() {
+                window.open(url);
+            }
+            """)
+        taptool.callback = tap_callback
+
         page_content = layout([
             [embed, image_plot],
             controls,

--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -186,6 +186,33 @@ def transfer_functions(colors):
     return transfer_functions
 
 
+def volume_rendering(image_filename, image_info, url, transfer_functions):
+    """3D volume rendering saved to html file with ipyvolume.
+    Parameters
+    ----------
+    index :
+    data :
+    url :
+    transfer_functions :
+    Returns
+    -------
+    """
+    ipv.pylab.clear()
+    image_3d = io.imread(image_filename)
+    image_3d = np.moveaxis(image_3d, 1, 0)
+    print(image_3d.shape)
+    #possible_colors = ['red', 'green', 'blue', 'grey', 'cyan', 'magenta', 'yellow']
+    #colors = possible_colors[:image_3d.shape[0]]
+    # should make transfer functions if none passed in
+    fig = ipv.figure()
+    fig.vol = None
+    ipv.pylab.style.box_off()
+    ipv.pylab.style.axes_off()
+    for channel, transfer_function in zip(image_3d, transfer_functions):
+        ipv.volshow(channel, tf=transfer_function)
+    ipv.embed.embed_html('./tmp/'+url, ipv.gcc(), title=image_info)
+
+
 def _column_range(series):
     minc = np.min(series)
     maxc = np.max(series)

--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -224,6 +224,7 @@ def volume_rendering(image_filename, image_info, url, transfer_functions):
     Returns
     -------
     """
+    print('Volume rendering...')
     ipv.pylab.clear()
     image_3d = io.imread(image_filename)
     image_3d = np.moveaxis(image_3d, 1, 0)
@@ -404,6 +405,7 @@ def make_makedoc(filename, color_column=None):
         A makedoc function as expected by ``FunctionHandler``.
     """
     dataframe = dataframe_from_file(filename)
+    volume_rendering_transfer_functions = transfer_functions(['red', 'green'])
 
     def makedoc(doc):
         source = ColumnDataSource(dataframe)
@@ -422,17 +424,28 @@ def make_makedoc(filename, color_column=None):
             if len(new.indices) == 1:  # could be empty selection
                 update_image_canvas_single(new.indices[0], data=dataframe,
                                            source=image_holder)
+                image_filename = dataframe['path'].iloc[new.indices[0]]
+                image_info = dataframe['info'].iloc[new.indices[0]]
+                volume_rendering(image_filename, image_info, url_base,
+                                 volume_rendering_transfer_functions)
             elif len(new.indices) > 1:
                 update_image_canvas_multi(new.indices, data=dataframe,
                                           source=image_holder)
             update_table(new.indices, dataframe, table)
         source.on_change('selected', load_selected)
 
-        tap_callback = CustomJS(args=dict(url=url, source=table.source), code="""
+        tap_callback = CustomJS(args=dict(url=url), code="""
             function myFunction() {
                 window.open(url);
             }
+            console.log(url)
             setTimeout(myFunction, 2000);
+            //var columns = Object.keys(source.data);
+            //var nrows = source.data[columns[0]].length;
+            //console.log(nrows);
+            //if (nrows == 0) {
+            //    setTimeout(myFunction, 2000);
+            //}
             """)
         taptool.callback = tap_callback
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ click
 bokeh>=0.13
 scikit-learn
 scikit-image
+ipyvolume
 six
 toolz
 cytoolz


### PR DESCRIPTION
Work in progress - DO NOT MERGE

- [x] Maximum intensity projections to display 3d data on image plot
- [x] Click to open volume rendering of 3d image in new browser tab
- [ ] Need to stop the taptool opening a window for every tap. We just want taps where ONE datapoint was selected.
- [ ] Uh, may have broken the colour scatterplot feature. microscopium might be expecting only strings in the color_column, and doesn't enjoy finding numeric values there instead - should investigate further.

