### PR TITLE
Upgrade to bokeh 1.0.0

### DIFF
--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -300,17 +300,17 @@ def make_makedoc(filename, color_column=None):
 
         def load_selected(attr, old, new):
             """Update images and table to display selected data."""
-            print('new index: ', new.indices)
+            print('new index: ', new)
             # Update images & table
-            if len(new.indices) == 1:  # could be empty selection
-                update_image_canvas_single(new.indices[0], data=dataframe,
+            if len(new) == 1:  # could be empty selection
+                update_image_canvas_single(new[0], data=dataframe,
                                            source=image_holder)
-            elif len(new.indices) > 1:
-                update_image_canvas_multi(new.indices, data=dataframe,
+            elif len(new) > 1:
+                update_image_canvas_multi(new, data=dataframe,
                                           source=image_holder)
-            update_table(new.indices, dataframe, table)
+            update_table(new, dataframe, table)
 
-        source.on_change('selected', load_selected)
+        source.selected.on_change('indices', load_selected)
         page_content = layout([
             [embed, image_plot],
             controls,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
 click
-bokeh>=0.13
+bokeh>=1.0.0
 scikit-learn
 scikit-image
 six


### PR DESCRIPTION
Updated microscopium to rely on bokeh 1.0.0 or higher.

Closes https://github.com/microscopium/microscopium/issues/89 (the weird javascript error is now magically fixed, hooray)

Big thanks to @bryevdv for suggesting the patch here: https://github.com/microscopium/microscopium/issues/89#issuecomment-430070789