### PR TITLE
BUGFIX: support for numeric data with command line --color-column (issue 110)

### DIFF
--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -17,7 +17,7 @@ from bokeh.layouts import widgetbox, layout
 from bokeh.models import (ColumnDataSource,
                           CustomJS,
                           CDSView,
-                          GroupFilter,
+                          BooleanFilter,
                           Legend)
 from bokeh.models.widgets import Button, DataTable, TableColumn
 import bokeh.palettes
@@ -180,13 +180,15 @@ def embedding(source, glyph_size=1, color_column='group'):
                    active_drag="box_select",
                    tooltips=tooltips_scatter)
     if color_column in source.data:
-        group_names = pd.Series(source.data[color_column]).unique()
+        group_names = sorted(set(source.data[color_column]))
         my_colors = _palette(len(group_names))
         for i, group in enumerate(group_names):
-            group_filter = GroupFilter(column_name=color_column, group=group)
+            boolean_indexing = source.data[color_column] == group
+            group_filter = BooleanFilter(boolean_indexing)
             view = CDSView(source=source, filters=[group_filter])
             glyphs = embed.circle(x="x", y="y", source=source, view=view,
-                                  size=10, color=my_colors[i], legend=group)
+                                  size=10, color=my_colors[i],
+                                  legend=str(group))
         embed.legend.location = "top_right"
         embed.legend.click_policy = "hide"
     else:


### PR DESCRIPTION
Closes https://github.com/microscopium/microscopium/issues/110

- [x] Replaced bokeh GroupFilter with BooleanFilter instead, so now we can pass numeric data and get categorical color coding with a legend.
- [x] Abstracted plotting glyphs to private functions _plot_categorical_data() and _plot_continuous_data()

@jni you said earlier that:
> For float data, and maybe even numeric (int) data, we should do a linear colormap and present a colorbar (maybe with sliders), instead of a legend. I think for the latter category (ints) we should have some threshold on the maximum number of unique values before it goes from legend to colorbar.

What threshold do you want for this? 
It's easy enough to edit the if isinstance(...) statement at line 217  in microscopium/serve.py