### PR TITLE
Make legend slightly transparent.

### DIFF
--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -189,6 +189,7 @@ def embedding(source, glyph_size=1, color_column='group'):
                                   size=10, color=my_colors[i], legend=group)
         embed.legend.location = "top_right"
         embed.legend.click_policy = "hide"
+        embed.legend.background_fill_alpha = 0.5
     else:
         embed.circle(source=source, x='x', y='y', size=glyph_size)
     return embed


### PR DESCRIPTION
I've made the legend slightly transparent on the bokeh scatterplot, so you can still see the datapoints underneath. 

(It's a little harder to see the effect with the test data because there's only a few points, but this does make a biggish difference for larger datasets).

Closes https://github.com/microscopium/microscopium/issues/96
