### PR TITLE
Update environment.yml, must have bokeh>=1.0.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
 - networkx
 - numpy
 - pandas
-- bokeh>=0.13
+- bokeh>=1.0.0
 - pip
 - pymongo=3*
 - scikit-image


### PR DESCRIPTION
Turns out I forgot to update `environment.yml` with the requirement for bokeh>=1.0.0 in PR https://github.com/microscopium/microscopium/pull/108 (but I did remember to update `requriments.txt`).

Is there a reason we have both? If so then we should just merge this fix, but if not then we should consider removing one to prevent similar mistakes later on.

