### PR TITLE
Print web app url in the terminal when the bokeh server is launched

### DIFF
--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -394,17 +394,20 @@ def default_config(filename):
 @click.option('-c', '--config', default=None)
 @click.option('-p', '--path', default='/')
 @click.option('-P', '--port', type=int, default=5000)
-def run_server_cmd(filename, config=None, path='/', port=5000):
+@click.option('-u', '--url', default='http://localhost')
+def run_server_cmd(filename, config=None, path='/', port=5000,
+                   url='http://localhost'):
     run_server(filename, config=config, path=path, port=port)
 
 
-def run_server(filename, config=None, path='/', port=5000):
+def run_server(filename, config=None, path='/', port=5000,
+               url='http://localhost'):
     """Run the bokeh server."""
     if config is None:
         config = default_config(filename)
     makedoc = make_makedoc(filename, config)
     apps = {path: Application(FunctionHandler(makedoc))}
-
+    print('Web app now available at {}:{}'.format(url, port))
     server = Server(apps, port=port, allow_websocket_origin=['*'])
     server.run_until_shutdown()
 

--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -407,8 +407,8 @@ def run_server(filename, config=None, path='/', port=5000,
         config = default_config(filename)
     makedoc = make_makedoc(filename, config)
     apps = {path: Application(FunctionHandler(makedoc))}
-    print('Web app now available at {}:{}'.format(url, port))
     server = Server(apps, port=port, allow_websocket_origin=['*'])
+    print('Web app now available at {}:{}'.format(url, port))
     server.run_until_shutdown()
 
 


### PR DESCRIPTION
Closes https://github.com/microscopium/microscopium/issues/161

Couple of questions for you @jni 
* Is adding the colon plus port number `:5000`
* Does this need to be more clickable from the terminal? On a Mac you can right-click then choose "Open URL", but is this slightly too inconvenient?
* If we make it clickable, how can we do this in a way that (1) works for as many platforms as possible (Linux, Mac, Windows), and (2) in a way that doesn't break things on another platform.

