### PR TITLE
Update serve.py to respect --url arg

### DIFF
--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -397,7 +397,7 @@ def default_config(filename):
 @click.option('-u', '--url', default='http://localhost')
 def run_server_cmd(filename, config=None, path='/', port=5000,
                    url='http://localhost'):
-    run_server(filename, config=config, path=path, port=port)
+    run_server(filename, config=config, path=path, port=port, url=url)
 
 
 def run_server(filename, config=None, path='/', port=5000,


### PR DESCRIPTION
Bugfix that updates PR https://github.com/microscopium/microscopium/pull/166

Currently the url keyword argument is not being passed through from `run_server_cmd()` to `run_server()`.