### PR TITLE
Pin bokeh to =>1.0.0 and <2.0.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - networkx
   - numpy
   - pandas
-  - bokeh>=1.0.0
+  - bokeh==1.*
   - pip
   - scikit-image
   - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -1,24 +1,25 @@
 name: mic
-channels: conda-forge
+channels:
+  - conda-forge
 dependencies:
-- python>=3.6*
-- click
-- cytoolz
-- h5py
-- matplotlib
-- networkx
-- numpy
-- pandas
-- bokeh>=1.0.0
-- pip
-- scikit-image
-- scikit-learn
-- scipy
-- setuptools
-- toolz
-- imageio
-- pyyaml
-- coverage>=4.0
-- pytest>=2.8
-- pytest-cov>=2.2
-- sh>=1.11
+  - python>=3.6*
+  - click
+  - cytoolz
+  - h5py
+  - matplotlib
+  - networkx
+  - numpy
+  - pandas
+  - bokeh>=1.0.0
+  - pip
+  - scikit-image
+  - scikit-learn
+  - scipy
+  - setuptools
+  - toolz
+  - imageio
+  - pyyaml
+  - coverage>=4.0
+  - pytest>=2.8
+  - pytest-cov>=2.2
+  - sh>=1.11


### PR DESCRIPTION
Here's a quick fix that closes https://github.com/microscopium/microscopium/issues/173

By pinning `bokeh==1.*` in the `environment.yml` file we avoid the breaking changes associated with the bokeh version 2 API.

We'll still need to upgrade properly to bokeh version 2, but this keeps things working in the meantime. New users will still be able to try out the demo from the README.
